### PR TITLE
docs: add cleanup instructions and minimal README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ lerna-debug.log*
 
 node_modules
 dist
+
+# Use Bun only — ignore other package manager lockfiles so they aren't committed
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
 dist-ssr
 *.local
 

--- a/README.md
+++ b/README.md
@@ -1,73 +1,12 @@
-# React + TypeScript + Vite
+# Phoenix UI
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React + TypeScript frontend built with Vite and Bun.
 
-Currently, two official plugins are available:
+## Quick Start
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+bun install
+bun run dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+See [bun-migration.md](./bun-migration.md) for detailed setup instructions.

--- a/bun-migration.md
+++ b/bun-migration.md
@@ -1,0 +1,138 @@
+# Phoenix UI
+
+This project uses **[Bun](https://bun.com)** only (no npm, yarn, or pnpm). Use the instructions below to install Bun and run the app.
+
+---
+
+## Do I still need package.json?
+
+**Yes.** `package.json` is the standard project manifest and is used by both npm and Bun. We keep `package.json` for dependencies, scripts, and metadata. The only change from npm is:
+
+- **Lockfile:** We use **`bun.lock`** (committed to git), not `package-lock.json`. Do not run `npm install` or `yarn` in this repo — use `bun install` only.
+
+---
+
+## For teammates: switching from npm to Bun
+
+### 1. Install Bun (macOS)
+
+Pick one method ([official install docs](https://bun.com/docs/installation)):
+
+**macOS (recommended):**
+```bash
+curl -fsSL https://bun.com/install | bash
+```
+
+**macOS (Homebrew):**
+```bash
+brew install oven-sh/bun/bun
+```
+
+Then **restart your terminal** and verify:
+
+```bash
+bun --version
+# Should show 1.2.5 or newer
+```
+
+If `bun` is not found, add Bun to your PATH (see [Bun installation](https://bun.com/docs/installation) — e.g. add `export PATH="$HOME/.bun/bin:$PATH"` to `~/.zshrc` or `~/.bashrc`).
+
+---
+
+### 2. Clone and install (first time)
+
+**Important:** Before running `bun install`, be sure to delete any existing `node_modules` and `package-lock.json`:
+
+```bash
+cd Phoenix
+rm -rf node_modules
+rm -f package-lock.json   # remove npm lockfile if still present
+bun install
+```
+
+Do **not** run `npm install` or `yarn`. This repo uses only `bun.lock`; other lockfiles are gitignored.
+
+---
+
+### 3. Daily commands
+
+| If you used npm…        | Use with Bun instead   |
+|-------------------------|------------------------|
+| `npm install`           | `bun install`          |
+| `npm run dev`            | `bun run dev`          |
+| `npm run build`         | `bun run build`        |
+| `npm run preview`       | `bun run preview`      |
+| `npm run lint`         | `bun run lint`         |
+| `npx <tool>`            | `bunx <tool>`          |
+| `npm install <pkg>`     | `bun add <pkg>`        |
+| `npm install -D <pkg>`  | `bun add -d <pkg>`     |
+| `npm uninstall <pkg>`   | `bun remove <pkg>`     |
+| `npm update`            | `bun update`           |
+| `npm outdated`          | `bun outdated`         |
+
+You can also shorten script runs: `bun dev` is the same as `bun run dev`.
+
+---
+
+### 4. Quick reference
+
+```bash
+# Install dependencies (after clone or when package.json changes)
+bun install
+
+# Start dev server (http://localhost:3000)
+bun run dev
+
+# Production build
+bun run build
+
+# Preview production build
+bun run preview
+
+# Lint
+bun run lint
+```
+
+---
+
+### 5. Adding / removing packages
+
+- **Add a dependency:**  
+  `bun add <package-name>`
+
+- **Add a dev dependency:**  
+  `bun add -d <package-name>`
+
+- **Remove a dependency:**  
+  `bun remove <package-name>`
+
+After adding or removing packages, commit both `package.json` and `bun.lock`.
+
+---
+
+### 6. Troubleshooting
+
+| Issue | What to do |
+|-------|------------|
+| `bun: command not found` | Install Bun (step 1) and add `~/.bun/bin` to your PATH. Restart the terminal. |
+| Wrong or missing dependencies | Delete `node_modules` and run `bun install` again. |
+| Script fails or behaves oddly | Ensure you're using Bun: `bun run <script>`, not `npm run <script>`. |
+| You ran `npm install` by mistake | Run `bun install` to align with `bun.lock`. Do not commit `package-lock.json` (it's gitignored). |
+
+---
+
+### 7. Project details
+
+- **Required Bun version:** 1.2.5 or newer (set in `package.json` via `packageManager`).
+- **Lockfile:** `bun.lock` (text format). Commit it so everyone gets the same dependency tree.
+- **Config:** Optional Bun settings are in `bunfig.toml` ([bunfig docs](https://bun.com/docs/runtime/bunfig)).
+- **Scripts:** Dev/build/preview use Vite with Bun's runtime (`bunx --bun vite`) for faster startup ([Bun + Vite](https://bun.com/docs/guides/ecosystem/vite)).
+
+---
+
+## Official docs
+
+- [Bun overview](https://bun.com/docs)
+- [Installation](https://bun.com/docs/installation)
+- [Migrate from npm to Bun](https://bun.com/docs/guides/install/from-npm-install-to-bun-install)
+- [Bun + Vite](https://bun.com/docs/guides/ecosystem/vite)

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,7 @@
+# Bun configuration for Phoenix UI
+# https://bun.com/docs/runtime/bunfig
+# Scripts use bunx --bun for Vite (see package.json).
+
+[install]
+# Keep text-based lockfile for readable diffs
+saveTextLockfile = true

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
+    "dev": "bunx --bun vite",
+    "build": "tsc -b && bunx --bun vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "bunx --bun vite preview"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,10 @@
 import path from "path"
+import { fileURLToPath } from "url"
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from "@tailwindcss/vite"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   resolve: {


### PR DESCRIPTION
- Add node_modules and package-lock.json cleanup steps to bun-migration.md
- Replace README.md with minimal version pointing to migration guide

Made-with: Cursor