### PR TITLE
Wired Frontend

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,9 @@
+# Copy to `.env.local` for local overrides (`.env.local` is gitignored).
+#
+# API base URL for axios (ResumeReviewDay, Committees, Career Fair, auth).
+# Leave empty to use the Vite dev server origin; `/api` and `/dashboard` are
+# proxied to the backend (see `vite.config.ts`, `VITE_API_TARGET`).
+VITE_HOST_URL=
+
+# Optional: backend URL for the dev proxy when `VITE_HOST_URL` is empty.
+# VITE_API_TARGET=http://127.0.0.1:8000

--- a/src/components/AdminGuard.tsx
+++ b/src/components/AdminGuard.tsx
@@ -1,19 +1,11 @@
 import { Navigate, useLocation } from "react-router-dom";
 
-const ADMIN_AUTH_KEY = "adminAuthenticated";
-
-export function isAdminAuthenticated(): boolean {
-  return typeof window !== "undefined" && localStorage.getItem(ADMIN_AUTH_KEY) === "true";
-}
-
-export function setAdminAuthenticated(value: boolean): void {
-  if (typeof window === "undefined") return;
-  if (value) {
-    localStorage.setItem(ADMIN_AUTH_KEY, "true");
-  } else {
-    localStorage.removeItem(ADMIN_AUTH_KEY);
-  }
-}
+import {
+  getIsStaffUser,
+  getMustChangePassword,
+  isAuthenticated,
+  logout,
+} from "@/services/AuthService";
 
 interface AdminGuardProps {
   children: React.ReactNode;
@@ -21,12 +13,22 @@ interface AdminGuardProps {
 
 /**
  * Protects admin routes: redirects to /admin/login if not authenticated.
+ * If the user must change their password, redirects to /admin/change-password.
  */
 export function AdminGuard({ children }: AdminGuardProps) {
   const location = useLocation();
 
-  if (!isAdminAuthenticated()) {
+  if (!isAuthenticated()) {
     return <Navigate to="/admin/login" state={{ from: location }} replace />;
+  }
+
+  if (!getIsStaffUser()) {
+    logout();
+    return <Navigate to="/" replace />;
+  }
+
+  if (getMustChangePassword() && location.pathname !== "/admin/change-password") {
+    return <Navigate to="/admin/change-password" replace />;
   }
 
   return <>{children}</>;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { isAdminAuthenticated, setAdminAuthenticated } from "@/components/AdminGuard";
+import { isAuthenticated, logout } from "@/services/AuthService";
 import { motion } from "framer-motion";
 import {
   Menu,
@@ -37,10 +37,10 @@ const Navbar: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const isAdmin = location.pathname.startsWith("/admin") && location.pathname !== "/admin/login";
-  const showLogout = isAdmin && isAdminAuthenticated();
+  const showLogout = isAdmin && isAuthenticated();
 
   const handleLogout = () => {
-    setAdminAuthenticated(false);
+    logout();
     navigate("/admin/login", { replace: true });
     setIsMenuOpen(false);
   };

--- a/src/components/RootLayout.tsx
+++ b/src/components/RootLayout.tsx
@@ -1,0 +1,12 @@
+import { Outlet, ScrollRestoration } from "react-router-dom";
+import { ScrollToTopButton } from "@/components/ScrollToTopButton";
+
+export function RootLayout() {
+  return (
+    <>
+      <Outlet />
+      <ScrollToTopButton />
+      <ScrollRestoration />
+    </>
+  );
+}

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { ChevronUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const SCROLL_THRESHOLD_PX = 400;
+
+export function ScrollToTopButton() {
+  const [visible, setVisible] = useState(false);
+  const reduceMotion = useReducedMotion();
+
+  useEffect(() => {
+    const onScroll = () => {
+      setVisible(window.scrollY > SCROLL_THRESHOLD_PX);
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    const instant =
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    window.scrollTo({ top: 0, behavior: instant ? "auto" : "smooth" });
+  };
+
+  return (
+    <AnimatePresence>
+      {visible ? (
+        <motion.div
+          role="presentation"
+          initial={reduceMotion ? false : { opacity: 0, scale: 0.9, y: 10 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          exit={reduceMotion ? undefined : { opacity: 0, scale: 0.9, y: 10 }}
+          transition={{ duration: reduceMotion ? 0 : 0.2 }}
+          className="fixed bottom-6 right-6 z-30"
+        >
+          <Button
+            type="button"
+            size="icon"
+            onClick={scrollToTop}
+            className={cn(
+              "size-11 rounded-full shadow-md",
+              "bg-[#E00122] text-white hover:bg-[#c00115]",
+              "focus-visible:ring-[#E00122]/35"
+            )}
+            aria-label="Back to top"
+          >
+            <ChevronUp className="size-5" aria-hidden />
+          </Button>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/src/pages/CareerFairPage.tsx
+++ b/src/pages/CareerFairPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef } from "react";
 import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import { motion, useInView } from "framer-motion";
 import {
   Briefcase,
@@ -17,6 +18,7 @@ import Footer from "@/components/Footer";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import careerFairBanner from "@/assets/tribunal-career-fair-banner.jpg";
+import { ResumeReviewDay } from "@/services/ResumeReviewService";
 
 type EventCard = {
   title: string;
@@ -57,6 +59,11 @@ function SectionHeader({
 export default function CareerFairPage() {
   const heroRef = useRef(null);
   const inView = useInView(heroRef, { once: true, margin: "-100px" });
+
+  const employersQuery = useQuery({
+    queryKey: ["rrd-employers"],
+    queryFn: () => ResumeReviewDay.getEmployers(),
+  });
 
   const careerWeekCards = useMemo<EventCard[]>(
     () => [
@@ -499,6 +506,86 @@ export default function CareerFairPage() {
                 </div>
               </Card>
             </div>
+          </div>
+        </section>
+
+        {/* Resume Review Day — employers signed up (public API) */}
+        <section className="py-16 lg:py-24 bg-white">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <motion.div
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true, margin: "-100px" }}
+              variants={fadeInUp}
+              transition={{ duration: 0.6 }}
+            >
+              <SectionHeader
+                eyebrow="Resume Review Day"
+                title="Signed up employers"
+                description="Industry partners registered for Engineering Resume Review Day. Open slots are 20-minute sessions still available for students to book."
+              />
+            </motion.div>
+
+            {employersQuery.isPending ? (
+              <div className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {[1, 2, 3].map((i) => (
+                  <Card
+                    key={i}
+                    className="p-6 lg:p-8 border-gray-200 overflow-hidden"
+                  >
+                    <div className="h-5 w-2/3 rounded bg-gray-200 animate-pulse" />
+                    <div className="mt-4 h-4 w-1/2 rounded bg-gray-100 animate-pulse" />
+                    <div className="mt-6 flex flex-wrap gap-2">
+                      <div className="h-6 w-20 rounded-full bg-gray-100 animate-pulse" />
+                      <div className="h-6 w-24 rounded-full bg-gray-100 animate-pulse" />
+                    </div>
+                    <div className="mt-4 h-4 w-28 rounded bg-gray-100 animate-pulse" />
+                  </Card>
+                ))}
+              </div>
+            ) : employersQuery.isError ? (
+              <div className="mt-10 rounded-xl border border-rose-200 bg-rose-50 px-4 py-6 text-center text-sm text-rose-800">
+                We couldn&apos;t load the employer list. Please try again later.
+              </div>
+            ) : employersQuery.data?.length === 0 ? (
+              <Card className="mt-10 p-8 lg:p-10 border-gray-200 text-center">
+                <p className="text-gray-600">
+                  No employers signed up yet. Check back as Resume Review Day
+                  approaches.
+                </p>
+              </Card>
+            ) : (
+              <div className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {employersQuery.data?.map((emp) => (
+                  <Card
+                    key={emp.id}
+                    className="p-6 lg:p-8 border-gray-200 flex flex-col h-full"
+                  >
+                    <h3 className="text-lg font-bold text-[#333333] leading-snug">
+                      {emp.company_name}
+                    </h3>
+                    <p className="mt-2 text-sm text-gray-600">{emp.full_name}</p>
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      {emp.selected_majors.map((major) => (
+                        <span
+                          key={major}
+                          className="inline-flex items-center rounded-full border border-gray-200 bg-[#F9FAFB] px-2.5 py-0.5 text-xs font-medium text-gray-700"
+                        >
+                          {major}
+                        </span>
+                      ))}
+                    </div>
+                    <p className="mt-auto pt-4 text-sm text-gray-600">
+                      <span className="font-semibold text-[#333333]">
+                        {emp.available_slots}
+                      </span>{" "}
+                      open slot
+                      {emp.available_slots === 1 ? "" : "s"}
+                    </p>
+                  </Card>
+                ))}
+              </div>
+            )}
           </div>
         </section>
 

--- a/src/pages/CommitteesPage.tsx
+++ b/src/pages/CommitteesPage.tsx
@@ -3,7 +3,8 @@
  * No section grouping; one flat grid of role cards. Colors and icons vary per card.
  */
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { motion, useInView, AnimatePresence } from "framer-motion";
 import {
   ChevronDown,
@@ -26,7 +27,6 @@ import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import {
   CommitteesService,
-  type ExecRoleSection,
   type ExecRoleItem,
   type ExecMemberPerson,
 } from "@/services/CommitteesService";
@@ -187,9 +187,15 @@ function RoleCard({
 }
 
 export default function CommitteesPage() {
-  const [sections, setSections] = useState<ExecRoleSection[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { data: sections = [], isPending: loading, isError, error } = useQuery({
+    queryKey: ["committees", "exec-role-with-members"],
+    queryFn: () => CommitteesService.getExecRoleSectionsWithMembers(),
+  });
+  const errorMessage = isError
+    ? error instanceof Error
+      ? error.message
+      : "Failed to load committees."
+    : null;
   const [expandedRoleId, setExpandedRoleId] = useState<number | null>(null);
 
   /** President and Chief of Staff first, then all other roles in their original order. */
@@ -204,25 +210,6 @@ export default function CommitteesPage() {
       (r): r is NonNullable<typeof r> => r != null
     );
   })();
-
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    CommitteesService.getExecRoleSectionsWithMembers()
-      .then((data) => {
-        if (!cancelled) setSections(data);
-      })
-      .catch((err) => {
-        if (!cancelled) setError(err?.message ?? "Failed to load committees.");
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   const handleScrollToMeetings = () => {
     window.scrollTo({ top: 0, behavior: "smooth" });
@@ -268,8 +255,8 @@ export default function CommitteesPage() {
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             {loading ? (
               <div className="text-center py-12 text-gray-500">Loading roles…</div>
-            ) : error ? (
-              <div className="text-center py-12 text-red-600">{error}</div>
+            ) : errorMessage ? (
+              <div className="text-center py-12 text-red-600">{errorMessage}</div>
             ) : allRoles.length === 0 ? (
               <div className="text-center py-12 text-gray-500">No roles yet.</div>
             ) : (

--- a/src/pages/ResumeReviewEmployer.tsx
+++ b/src/pages/ResumeReviewEmployer.tsx
@@ -34,7 +34,6 @@ type FormValues = {
   diet_restriction: string;
   start_time: string;
   end_time: string;
-  max_resumes: number;
   uc_alumni: boolean;
   selected_majors: string[];
 };
@@ -44,7 +43,6 @@ export default function ResumeReviewEmployer() {
     defaultValues: {
       uc_alumni: false,
       selected_majors: [],
-      max_resumes: 10,
     },
   });
 
@@ -138,9 +136,8 @@ export default function ResumeReviewEmployer() {
               with emerging talent, and help students put their best foot forward.
             </p>
             <p className="text-base text-black/80 text-center leading-relaxed">
-              Select the time window you will be available, the maximum number of resumes you would like to review,
-              and the majors you are most interested in meeting with. Once submitted, our team will confirm your
-              schedule and send you additional details.
+              Select the time window you will be available and the majors you are most interested in meeting with.
+              Once submitted, our team will confirm your schedule and send you additional details.
             </p>
             <p className="text-base text-black/80 text-center">
               If you have any questions, please contact us at{' '}
@@ -239,23 +236,6 @@ export default function ResumeReviewEmployer() {
                   />
                   {errors.end_time && <p className="text-rose-500 text-xs mt-1">This field is required</p>}
                 </div>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Maximum Resumes (max 20)</label>
-                <input
-                  type="number"
-                  {...register("max_resumes", { required: true, min: 1, max: 20 })}
-                  className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-sky-500 bg-white"
-                  placeholder="Number of students you can see"
-                  min={1}
-                  max={100}
-                />
-                {errors.max_resumes && (
-                  <p className="text-rose-500 text-xs mt-1">
-                    Must be between 1 and 100
-                  </p>
-                )}
               </div>
 
               <div className="flex items-center justify-between py-2 px-3 rounded-lg bg-slate-50 border border-slate-200">

--- a/src/pages/admin/AdminChangePasswordPage.tsx
+++ b/src/pages/admin/AdminChangePasswordPage.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useState } from "react";
+import type { FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { motion } from "framer-motion";
+import { KeyRound, ArrowLeft } from "lucide-react";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  changePassword,
+  formatErrorMessage,
+  isAuthenticated,
+  logout,
+  refreshMe,
+} from "@/services/AuthService";
+
+function validateNewPassword(pw: string, uname: string): string | null {
+  if (pw.length <= 5) {
+    return "Password must be more than 5 characters.";
+  }
+  if (!/^[a-zA-Z0-9]+$/.test(pw)) {
+    return "Password must contain only letters and numbers.";
+  }
+  if (pw === uname) {
+    return "Password cannot be the same as your username.";
+  }
+  return null;
+}
+
+export default function AdminChangePasswordPage() {
+  const navigate = useNavigate();
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [clientError, setClientError] = useState<string | null>(null);
+
+  const sessionQuery = useQuery({
+    queryKey: ["auth-me"],
+    queryFn: refreshMe,
+    enabled: isAuthenticated(),
+    retry: false,
+  });
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      changePassword({
+        old_password: currentPassword,
+        new_password: newPassword,
+        new_password_confirm: confirmPassword,
+      }),
+    onSuccess: () => {
+      navigate("/admin", { replace: true });
+    },
+    onError: (err: unknown) => {
+      setClientError(formatErrorMessage(err));
+    },
+  });
+
+  useEffect(() => {
+    if (!isAuthenticated()) {
+      navigate("/admin/login", { replace: true });
+    }
+  }, [navigate]);
+
+  useEffect(() => {
+    if (sessionQuery.isError) {
+      logout();
+      navigate("/admin/login", { replace: true });
+    }
+  }, [sessionQuery.isError, navigate]);
+
+  useEffect(() => {
+    const me = sessionQuery.data;
+    if (me && !me.must_change_password) {
+      navigate("/admin", { replace: true });
+    }
+  }, [sessionQuery.data, navigate]);
+
+  if (!isAuthenticated()) {
+    return null;
+  }
+
+  if (sessionQuery.isLoading) {
+    return (
+      <div className="min-h-screen bg-white">
+        <Navbar />
+        <main className="min-h-screen bg-white">
+          <section className="py-16 lg:py-24">
+            <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+              <Card className="max-w-md mx-auto border-gray-200 shadow-sm">
+                <CardContent className="py-12 text-center text-gray-600">
+                  Loading your session…
+                </CardContent>
+              </Card>
+            </div>
+          </section>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  const me = sessionQuery.data;
+  if (!me?.must_change_password) {
+    return null;
+  }
+
+  const username = me.username;
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setClientError(null);
+
+    if (newPassword !== confirmPassword) {
+      setClientError("New passwords do not match.");
+      return;
+    }
+
+    const local = validateNewPassword(newPassword, username);
+    if (local) {
+      setClientError(local);
+      return;
+    }
+
+    mutation.mutate();
+  }
+
+  return (
+    <div className="min-h-screen bg-white">
+      <Navbar />
+      <main className="min-h-screen bg-white">
+        <section className="py-16 lg:py-24">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <motion.div
+              className="max-w-md mx-auto"
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3 }}
+            >
+              <button
+                type="button"
+                className="inline-flex items-center gap-2 text-sm font-medium text-[#E00122] hover:underline mb-6"
+                onClick={() => {
+                  logout();
+                  navigate("/admin/login", { replace: true });
+                }}
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Back to login
+              </button>
+
+              <Card className="border-gray-200 shadow-sm">
+                <CardHeader className="space-y-1">
+                  <div className="flex items-center gap-2 text-[#E00122]">
+                    <KeyRound className="h-5 w-5" />
+                    <CardTitle className="text-2xl font-bold tracking-tight">
+                      Change password
+                    </CardTitle>
+                  </div>
+                  <CardDescription className="text-gray-600">
+                    You must set a new password before continuing. Use more than 5 characters, letters
+                    and numbers only, and do not reuse your username ({username}).
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+                    <div className="space-y-2">
+                      <Label htmlFor="current-pw" className="text-[#333333]">
+                        Current password
+                      </Label>
+                      <Input
+                        id="current-pw"
+                        type="password"
+                        value={currentPassword}
+                        onChange={(e) => {
+                          setCurrentPassword(e.target.value);
+                          setClientError(null);
+                        }}
+                        className="border-gray-200 focus-visible:ring-[#E00122]/50"
+                        autoComplete="current-password"
+                        disabled={mutation.isPending}
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="new-pw" className="text-[#333333]">
+                        New password
+                      </Label>
+                      <Input
+                        id="new-pw"
+                        type="password"
+                        value={newPassword}
+                        onChange={(e) => {
+                          setNewPassword(e.target.value);
+                          setClientError(null);
+                        }}
+                        className="border-gray-200 focus-visible:ring-[#E00122]/50"
+                        autoComplete="new-password"
+                        disabled={mutation.isPending}
+                        required
+                        aria-describedby="pw-rules"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="confirm-pw" className="text-[#333333]">
+                        Confirm new password
+                      </Label>
+                      <Input
+                        id="confirm-pw"
+                        type="password"
+                        value={confirmPassword}
+                        onChange={(e) => {
+                          setConfirmPassword(e.target.value);
+                          setClientError(null);
+                        }}
+                        className="border-gray-200 focus-visible:ring-[#E00122]/50"
+                        autoComplete="new-password"
+                        disabled={mutation.isPending}
+                        required
+                      />
+                    </div>
+                    <p id="pw-rules" className="text-xs text-gray-500">
+                      More than 5 characters. Letters and numbers only. Cannot match your username.
+                    </p>
+                    {clientError && (
+                      <p className="text-sm text-red-600" role="alert" aria-live="polite">
+                        {clientError}
+                      </p>
+                    )}
+                    <Button
+                      type="submit"
+                      className="w-full bg-[#E00122] text-white hover:bg-[#B8011C] rounded-md"
+                      disabled={
+                        mutation.isPending ||
+                        !currentPassword ||
+                        !newPassword ||
+                        !confirmPassword
+                      }
+                    >
+                      {mutation.isPending ? "Updating…" : "Update password"}
+                    </Button>
+                  </form>
+                </CardContent>
+              </Card>
+            </motion.div>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/admin/AdminDashboardPage.tsx
+++ b/src/pages/admin/AdminDashboardPage.tsx
@@ -7,6 +7,7 @@ import {
   ArrowRight,
   BarChart3,
   TrendingUp,
+  ClipboardList,
 } from "lucide-react";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
@@ -45,6 +46,12 @@ const DASHBOARD_LINKS = [
     description: "Print name tags for representatives; select printer and location.",
     icon: Printer,
   },
+  {
+    href: "/admin/resume-review-day/roster",
+    title: "Resume Review Day Roster",
+    description: "View employers and students signed up for Resume Review Day.",
+    icon: ClipboardList,
+  },
 ] as const;
 
 const eventChartConfig = chartConfigEventAttendance;
@@ -70,7 +77,8 @@ export default function AdminDashboardPage() {
                 Admin Dashboard
               </h1>
               <p className="mt-2 text-base text-gray-600">
-                Manage reimbursements, career fair sign-in, and tags. View engagement metrics below.
+                Manage reimbursements, career fair sign-in, tags, and the Resume Review Day roster.
+                View engagement metrics below.
               </p>
             </motion.div>
 

--- a/src/pages/admin/AdminLoginPage.tsx
+++ b/src/pages/admin/AdminLoginPage.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import type { FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
+import { useMutation } from "@tanstack/react-query";
 import { motion } from "framer-motion";
 import { LogIn } from "lucide-react";
 import Navbar from "@/components/Navbar";
@@ -9,36 +10,71 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { setAdminAuthenticated, isAdminAuthenticated } from "@/components/AdminGuard";
-
-const HARDCODED_EMAIL = "123";
-const HARDCODED_PASSWORD = "123";
+import {
+  formatErrorMessage,
+  isAuthenticated,
+  login,
+  logout,
+  refreshMe,
+} from "@/services/AuthService";
 
 export default function AdminLoginPage() {
   const navigate = useNavigate();
-  const [email, setEmail] = useState("");
+  const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
 
+  const loginMutation = useMutation({
+    mutationFn: () => login(username, password),
+    onSuccess: (result) => {
+      if (result.mustChangePassword) {
+        navigate("/admin/change-password", { replace: true });
+      } else {
+        navigate("/admin", { replace: true });
+      }
+    },
+    onError: (err: unknown) => {
+      setError(formatErrorMessage(err));
+    },
+  });
+
   useEffect(() => {
-    if (isAdminAuthenticated()) {
-      navigate("/admin", { replace: true });
-    }
+    if (!isAuthenticated()) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const me = await refreshMe();
+        if (cancelled) return;
+        if (!me.is_staff) {
+          logout();
+          navigate("/", { replace: true });
+          return;
+        }
+        if (me.must_change_password) {
+          navigate("/admin/change-password", { replace: true });
+        } else {
+          navigate("/admin", { replace: true });
+        }
+      } catch {
+        if (!cancelled) {
+          logout();
+          navigate("/admin/login", { replace: true });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [navigate]);
 
-  if (isAdminAuthenticated()) {
+  if (isAuthenticated()) {
     return null;
   }
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
     setError(null);
-    if (email === HARDCODED_EMAIL && password === HARDCODED_PASSWORD) {
-      setAdminAuthenticated(true);
-      navigate("/admin", { replace: true });
-    } else {
-      setError("Invalid email or password. Use 123 / 123 for demo.");
-    }
+    loginMutation.mutate();
   }
 
   return (
@@ -60,23 +96,24 @@ export default function AdminLoginPage() {
                     <CardTitle className="text-2xl font-bold tracking-tight">Admin Login</CardTitle>
                   </div>
                   <CardDescription className="text-gray-600">
-                    Sign in with your executive credentials to access the admin dashboard.
+                    Staff sign-in: use your executive username (6+2) and password (same as Django admin).
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
                   <form onSubmit={handleSubmit} className="space-y-4">
                     <div className="space-y-2">
-                      <Label htmlFor="admin-email" className="text-[#333333]">
-                        Email
+                      <Label htmlFor="admin-username" className="text-[#333333]">
+                        Username
                       </Label>
                       <Input
-                        id="admin-email"
+                        id="admin-username"
                         type="text"
-                        placeholder="Enter email"
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="Your 6+2"
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
                         className="border-gray-200 focus-visible:ring-[#E00122]/50"
                         autoComplete="username"
+                        disabled={loginMutation.isPending}
                       />
                     </div>
                     <div className="space-y-2">
@@ -91,6 +128,7 @@ export default function AdminLoginPage() {
                         onChange={(e) => setPassword(e.target.value)}
                         className="border-gray-200 focus-visible:ring-[#E00122]/50"
                         autoComplete="current-password"
+                        disabled={loginMutation.isPending}
                       />
                     </div>
                     {error && (
@@ -101,8 +139,9 @@ export default function AdminLoginPage() {
                     <Button
                       type="submit"
                       className="w-full bg-[#E00122] text-white hover:bg-[#B8011C] rounded-md"
+                      disabled={loginMutation.isPending || !username.trim() || !password}
                     >
-                      Sign in
+                      {loginMutation.isPending ? "Signing in…" : "Sign in"}
                     </Button>
                   </form>
                 </CardContent>

--- a/src/pages/admin/AdminRepresentativeSignInPage.tsx
+++ b/src/pages/admin/AdminRepresentativeSignInPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { FormEvent } from "react";
 import { Link } from "react-router-dom";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { motion } from "framer-motion";
 import { UserPlus, ArrowLeft, CheckCircle } from "lucide-react";
 import Navbar from "@/components/Navbar";
@@ -10,6 +11,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  CAREER_FAIR_REPRESENTATIVES_QUERY_KEY,
+  formatErrorMessage,
+  signInRepresentative,
+} from "@/services/CareerFairService";
 
 const LOCATION_OPTIONS = [
   { value: "rec-center", label: "REC Center" },
@@ -17,6 +23,7 @@ const LOCATION_OPTIONS = [
 ] as const;
 
 export default function AdminRepresentativeSignInPage() {
+  const queryClient = useQueryClient();
   const [name, setName] = useState("");
   const [company, setCompany] = useState("");
   const [title, setTitle] = useState("");
@@ -24,12 +31,41 @@ export default function AdminRepresentativeSignInPage() {
   const [boothLocation, setBoothLocation] = useState("");
   const [location, setLocation] = useState<string>("");
   const [signedIn, setSignedIn] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const signInMutation = useMutation({
+    mutationFn: () =>
+      signInRepresentative({
+        name: name.trim(),
+        company: company.trim(),
+        title: title.trim(),
+        email: email.trim(),
+        booth_location: boothLocation.trim(),
+        building_location: location,
+      }),
+    onSuccess: () => {
+      setError(null);
+      setSignedIn(true);
+      void queryClient.invalidateQueries({ queryKey: [...CAREER_FAIR_REPRESENTATIVES_QUERY_KEY] });
+    },
+    onError: (err: unknown) => {
+      setError(formatErrorMessage(err));
+    },
+  });
+
+  const formValid =
+    name.trim() &&
+    company.trim() &&
+    title.trim() &&
+    email.trim() &&
+    boothLocation.trim() &&
+    location;
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    if (location) {
-      setSignedIn(true);
-    }
+    setError(null);
+    if (!formValid) return;
+    signInMutation.mutate();
   }
 
   function handleSignInAnother() {
@@ -40,6 +76,7 @@ export default function AdminRepresentativeSignInPage() {
     setBoothLocation("");
     setLocation("");
     setSignedIn(false);
+    setError(null);
   }
 
   return (
@@ -103,6 +140,8 @@ export default function AdminRepresentativeSignInPage() {
                           onChange={(e) => setName(e.target.value)}
                           placeholder="Name"
                           className="border-gray-200"
+                          disabled={signInMutation.isPending}
+                          required
                         />
                       </div>
                       <div className="space-y-2">
@@ -113,6 +152,8 @@ export default function AdminRepresentativeSignInPage() {
                           onChange={(e) => setCompany(e.target.value)}
                           placeholder="Company"
                           className="border-gray-200"
+                          disabled={signInMutation.isPending}
+                          required
                         />
                       </div>
                       <div className="space-y-2">
@@ -123,6 +164,8 @@ export default function AdminRepresentativeSignInPage() {
                           onChange={(e) => setTitle(e.target.value)}
                           placeholder="Title"
                           className="border-gray-200"
+                          disabled={signInMutation.isPending}
+                          required
                         />
                       </div>
                       <div className="space-y-2">
@@ -134,6 +177,8 @@ export default function AdminRepresentativeSignInPage() {
                           onChange={(e) => setEmail(e.target.value)}
                           placeholder="Email"
                           className="border-gray-200"
+                          disabled={signInMutation.isPending}
+                          required
                         />
                       </div>
                       <div className="space-y-2">
@@ -144,6 +189,8 @@ export default function AdminRepresentativeSignInPage() {
                           onChange={(e) => setBoothLocation(e.target.value)}
                           placeholder="ex: A15"
                           className="border-gray-200"
+                          disabled={signInMutation.isPending}
+                          required
                         />
                       </div>
                       <div className="space-y-3">
@@ -151,7 +198,8 @@ export default function AdminRepresentativeSignInPage() {
                         <RadioGroup
                           value={location}
                           onValueChange={setLocation}
-                          className="flex gap-6"
+                          className="flex flex-wrap gap-6"
+                          disabled={signInMutation.isPending}
                         >
                           {LOCATION_OPTIONS.map((loc) => (
                             <div key={loc.value} className="flex items-center gap-2">
@@ -163,12 +211,17 @@ export default function AdminRepresentativeSignInPage() {
                           ))}
                         </RadioGroup>
                       </div>
+                      {error && (
+                        <p className="text-sm text-red-600" role="alert">
+                          {error}
+                        </p>
+                      )}
                       <Button
                         type="submit"
                         className="w-full bg-[#E00122] text-white hover:bg-[#B8011C] rounded-md"
-                        disabled={!location}
+                        disabled={!formValid || signInMutation.isPending}
                       >
-                        Sign in
+                        {signInMutation.isPending ? "Signing in…" : "Sign in"}
                       </Button>
                     </form>
                   )}

--- a/src/pages/admin/AdminResumeRosterPage.tsx
+++ b/src/pages/admin/AdminResumeRosterPage.tsx
@@ -1,0 +1,257 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { motion } from "framer-motion";
+import { ArrowLeft, ChevronDown, ClipboardList } from "lucide-react";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ResumeReviewDay, type RosterEmployer } from "@/services/ResumeReviewService";
+import { formatErrorMessage, isAuthenticated } from "@/services/AuthService";
+
+function slotsTaken(emp: RosterEmployer): { taken: number; total: number } {
+  const total = emp.slots.length;
+  const taken = emp.slots.filter((s) => s.student !== null).length;
+  return { taken, total };
+}
+
+export default function AdminResumeRosterPage() {
+  const [search, setSearch] = useState("");
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const rosterQuery = useQuery({
+    queryKey: ["rrd-roster"],
+    queryFn: () => ResumeReviewDay.getRoster(),
+    enabled: isAuthenticated(),
+  });
+
+  const filtered = useMemo(() => {
+    const rows = rosterQuery.data ?? [];
+    const q = search.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter(
+      (e) =>
+        e.company_name.toLowerCase().includes(q) ||
+        e.full_name.toLowerCase().includes(q)
+    );
+  }, [rosterQuery.data, search]);
+
+  const errorMessage =
+    rosterQuery.isError && rosterQuery.error
+      ? formatErrorMessage(rosterQuery.error)
+      : null;
+
+  function toggleExpanded(id: string) {
+    setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
+  }
+
+  return (
+    <div className="min-h-screen bg-white">
+      <Navbar />
+      <main className="min-h-screen bg-white">
+        <section className="py-16 lg:py-24">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <motion.div
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3 }}
+            >
+              <Link
+                to="/admin"
+                className="inline-flex items-center gap-2 text-sm font-medium text-[#E00122] hover:underline mb-6"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Back to Admin Dashboard
+              </Link>
+
+              <div className="mb-8">
+                <div className="flex items-center gap-3 text-[#E00122] mb-2">
+                  <ClipboardList className="h-8 w-8" />
+                  <h1 className="text-3xl font-bold tracking-tight text-[#333333]">
+                    Resume Review Day Roster
+                  </h1>
+                </div>
+                <p className="text-gray-600 max-w-2xl">
+                  Employers registered for Resume Review Day, their time windows, and
+                  which students claimed each 20-minute slot.
+                </p>
+              </div>
+
+              <div className="max-w-md space-y-2 mb-8">
+                <Label htmlFor="roster-search">Filter by company or employer name</Label>
+                <Input
+                  id="roster-search"
+                  type="search"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search…"
+                  className="border-gray-200"
+                  autoComplete="off"
+                />
+              </div>
+
+              {errorMessage && (
+                <p className="mb-6 text-sm text-red-600" role="alert">
+                  {errorMessage}
+                </p>
+              )}
+
+              {rosterQuery.isPending && (
+                <div className="space-y-4">
+                  {[1, 2, 3].map((i) => (
+                    <Card key={i} className="border-gray-200 overflow-hidden">
+                      <div className="p-6 animate-pulse space-y-3">
+                        <div className="h-6 w-1/3 rounded bg-gray-200" />
+                        <div className="h-4 w-1/4 rounded bg-gray-100" />
+                        <div className="h-4 w-1/2 rounded bg-gray-100" />
+                      </div>
+                    </Card>
+                  ))}
+                </div>
+              )}
+
+              {!rosterQuery.isPending && filtered.length === 0 && (
+                <Card className="border-gray-200">
+                  <CardContent className="py-12 text-center text-gray-600">
+                    {search.trim()
+                      ? "No employers match your search."
+                      : "No employers registered for Resume Review Day yet."}
+                  </CardContent>
+                </Card>
+              )}
+
+              {!rosterQuery.isPending && filtered.length > 0 && (
+                <div className="space-y-4">
+                  {filtered.map((emp) => {
+                    const { taken, total } = slotsTaken(emp);
+                    const isOpen = !!expanded[emp.id];
+                    return (
+                      <Card key={emp.id} className="border-gray-200 shadow-sm">
+                        <CardHeader className="pb-2">
+                          <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                            <div className="min-w-0">
+                              <CardTitle className="text-xl text-[#333333]">
+                                {emp.company_name}
+                              </CardTitle>
+                              <CardDescription className="text-gray-600 mt-1">
+                                {emp.full_name} · {emp.email}
+                              </CardDescription>
+                              <p className="text-sm text-gray-600 mt-2">
+                                Window: {emp.start_time} – {emp.end_time} · Max resumes:{" "}
+                                {emp.max_resumes}
+                              </p>
+                              <p className="text-sm font-medium text-[#333333] mt-1">
+                                {taken} / {total} slots taken
+                              </p>
+                              {emp.selected_majors.length > 0 && (
+                                <div className="flex flex-wrap gap-1.5 mt-3">
+                                  {emp.selected_majors.map((m) => (
+                                    <span
+                                      key={m}
+                                      className="inline-flex rounded-full border border-gray-200 bg-[#F9FAFB] px-2 py-0.5 text-xs text-gray-700"
+                                    >
+                                      {m}
+                                    </span>
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              className="shrink-0 border-gray-200"
+                              onClick={() => toggleExpanded(emp.id)}
+                              aria-expanded={isOpen}
+                            >
+                              {isOpen ? "Hide" : "Show"} timeslots
+                              <ChevronDown
+                                className={`ml-1 h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
+                              />
+                            </Button>
+                          </div>
+                        </CardHeader>
+                        {isOpen && (
+                          <CardContent className="pt-0">
+                            <div className="overflow-x-auto rounded-lg border border-gray-200">
+                              <table className="w-full min-w-[560px] text-sm">
+                                <thead>
+                                  <tr className="border-b border-gray-200 bg-gray-50">
+                                    <th className="px-4 py-3 text-left font-semibold text-[#333333]">
+                                      Time
+                                    </th>
+                                    <th className="px-4 py-3 text-left font-semibold text-[#333333]">
+                                      Student
+                                    </th>
+                                    <th className="px-4 py-3 text-left font-semibold text-[#333333]">
+                                      Major
+                                    </th>
+                                    <th className="px-4 py-3 text-left font-semibold text-[#333333]">
+                                      Grad year
+                                    </th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  {emp.slots.map((slot) => (
+                                    <tr
+                                      key={slot.slot_id}
+                                      className="border-b border-gray-100 last:border-0"
+                                    >
+                                      <td className="px-4 py-3 text-gray-800 whitespace-nowrap">
+                                        {slot.time}
+                                      </td>
+                                      <td className="px-4 py-3 text-gray-700">
+                                        {slot.student ? (
+                                          <>
+                                            <span className="font-medium">
+                                              {slot.student.full_name}
+                                            </span>
+                                            <br />
+                                            <a
+                                              href={`mailto:${slot.student.email}`}
+                                              className="text-xs text-[#E00122] hover:underline"
+                                            >
+                                              {slot.student.email}
+                                            </a>
+                                          </>
+                                        ) : (
+                                          <span className="text-gray-500 italic">
+                                            — Available —
+                                          </span>
+                                        )}
+                                      </td>
+                                      <td className="px-4 py-3 text-gray-700">
+                                        {slot.student?.major ?? "—"}
+                                      </td>
+                                      <td className="px-4 py-3 text-gray-700">
+                                        {slot.student?.grad_year ?? "—"}
+                                      </td>
+                                    </tr>
+                                  ))}
+                                </tbody>
+                              </table>
+                            </div>
+                          </CardContent>
+                        )}
+                      </Card>
+                    );
+                  })}
+                </div>
+              )}
+            </motion.div>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/admin/AdminTagsPrintingPage.tsx
+++ b/src/pages/admin/AdminTagsPrintingPage.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import { motion } from "framer-motion";
 import { Printer, ArrowLeft } from "lucide-react";
 import Navbar from "@/components/Navbar";
@@ -13,36 +14,113 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  CAREER_FAIR_REPRESENTATIVES_QUERY_KEY,
+  formatErrorMessage,
+  getRepresentatives,
+  type Representative,
+} from "@/services/CareerFairService";
 
 const PRINTER_OPTIONS = [
   { value: "dymo-450", label: "DYMO LabelWriter 450" },
   { value: "none", label: "No printer detected" },
 ] as const;
 
-const LOCATIONS = [
-  { value: "booth-a1", label: "Booth A1" },
-  { value: "booth-a2", label: "Booth A2" },
-  { value: "main-hall", label: "Main Hall" },
-  { value: "virtual", label: "Virtual" },
-] as const;
+function formatSignedInAt(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      dateStyle: "short",
+      timeStyle: "short",
+    });
+  } catch {
+    return iso;
+  }
+}
 
-const PLACEHOLDER_REPRESENTATIVES = [
-  { name: "Jane Smith", company: "Acme Corp", title: "Recruiter", booth: "A1", timeAdded: "9:15 AM" },
-  { name: "John Doe", company: "Tech Inc", title: "HR Manager", booth: "A2", timeAdded: "9:22 AM" },
-  { name: "Alex Johnson", company: "Engineering Co", title: "Campus Lead", booth: "Main Hall", timeAdded: "9:30 AM" },
-  { name: "Sam Williams", company: "Design Studio", title: "Talent Lead", booth: "A1", timeAdded: "9:45 AM" },
-  { name: "Jordan Lee", company: "Startup Labs", title: "Recruiter", booth: "Virtual", timeAdded: "10:00 AM" },
-];
+function buildingLabel(value: string): string {
+  if (value === "rec-center") return "REC Center";
+  if (value === "tuc-great-hall") return "TUC Great Hall";
+  return value;
+}
+
+function renderTableBody(
+  isLoading: boolean,
+  data: Representative[] | undefined,
+  onPrint: (rep: Representative) => void
+): ReactNode {
+  if (isLoading) {
+    return (
+      <tr>
+        <td colSpan={7} className="px-4 py-8 text-center text-gray-500">
+          Loading representatives…
+        </td>
+      </tr>
+    );
+  }
+  if (!data || data.length === 0) {
+    return (
+      <tr>
+        <td colSpan={7} className="px-4 py-8 text-center text-gray-500">
+          No representatives match this search.
+        </td>
+      </tr>
+    );
+  }
+  return data.map((rep) => (
+    <tr
+      key={rep.id}
+      className="border-b border-gray-100 last:border-0 hover:bg-gray-50/50"
+    >
+      <td className="px-4 py-3 text-gray-700">{rep.name}</td>
+      <td className="px-4 py-3 text-gray-700">{rep.company}</td>
+      <td className="px-4 py-3 text-gray-700">{rep.title}</td>
+      <td className="px-4 py-3 text-gray-700">{rep.booth_location}</td>
+      <td className="px-4 py-3 text-gray-700">{buildingLabel(rep.building_location)}</td>
+      <td className="px-4 py-3 text-gray-600">{formatSignedInAt(rep.signed_in_at)}</td>
+      <td className="px-4 py-3">
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="rounded-md"
+          onClick={() => onPrint(rep)}
+        >
+          Print
+        </Button>
+      </td>
+    </tr>
+  ));
+}
 
 export default function AdminTagsPrintingPage() {
   const [printer, setPrinter] = useState<string>("");
-  const [location, setLocation] = useState<string>("");
+  const [searchInput, setSearchInput] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
 
-  function handlePrint() {
-    // Placeholder: could call window.print() for demo
-    alert("Print tags (placeholder — no printer integration).");
+  useEffect(() => {
+    const t = window.setTimeout(() => setDebouncedSearch(searchInput.trim()), 300);
+    return () => window.clearTimeout(t);
+  }, [searchInput]);
+
+  const listQuery = useQuery({
+    queryKey: [...CAREER_FAIR_REPRESENTATIVES_QUERY_KEY, debouncedSearch],
+    queryFn: () => getRepresentatives(debouncedSearch || undefined),
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+    refetchInterval: 5000,
+  });
+
+  function handlePrintOne(rep: Representative) {
+    // DYMO integration will plug in here later
+    globalThis.alert(
+      `Print name tag (stub)\n\n${rep.name}\n${rep.company}\n${rep.title}\nBooth: ${rep.booth_location}\nPrinter: ${printer || "(not selected)"}`
+    );
   }
+
+  const errorMessage =
+    listQuery.isError && listQuery.error ? formatErrorMessage(listQuery.error) : null;
 
   return (
     <div className="min-h-screen bg-white">
@@ -70,58 +148,58 @@ export default function AdminTagsPrintingPage() {
                     <CardTitle className="text-2xl">Printing Station</CardTitle>
                   </div>
                   <CardDescription className="text-gray-600">
-                    Select a DYMO printer and location, then print name tags for representatives.
+                    Select a DYMO printer, search representatives, then print a name tag per row.
+                    Printer integration is stubbed until DYMO is connected.
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-8">
-                  {/* Printer Settings */}
                   <div className="space-y-4">
                     <h3 className="text-xs font-semibold uppercase tracking-wide text-[#E00122]">
-                      Printer Settings
+                      Printer
                     </h3>
-                    <div className="grid gap-4 sm:grid-cols-2">
-                      <div className="space-y-2">
-                        <Label>Select a connected DYMO printer</Label>
-                        <Select value={printer} onValueChange={setPrinter}>
-                          <SelectTrigger className="w-full border-gray-200">
-                            <SelectValue placeholder="Select printer" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {PRINTER_OPTIONS.map((opt) => (
-                              <SelectItem key={opt.value} value={opt.value}>
-                                {opt.label}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      <div className="space-y-2">
-                        <Label>Select Location</Label>
-                        <Select value={location} onValueChange={setLocation}>
-                          <SelectTrigger className="w-full border-gray-200">
-                            <SelectValue placeholder="Select location" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {LOCATIONS.map((loc) => (
-                              <SelectItem key={loc.value} value={loc.value}>
-                                {loc.label}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
+                    <div className="max-w-md space-y-2">
+                      <Label>Select a connected DYMO printer</Label>
+                      <Select value={printer} onValueChange={setPrinter}>
+                        <SelectTrigger className="w-full border-gray-200">
+                          <SelectValue placeholder="Select printer" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {PRINTER_OPTIONS.map((opt) => (
+                            <SelectItem key={opt.value} value={opt.value}>
+                              {opt.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                     </div>
                   </div>
 
-                  {/* Representatives Table */}
                   <div className="space-y-4">
                     <h3 className="text-xs font-semibold uppercase tracking-wide text-[#E00122]">
                       Representatives
                     </h3>
-                    <div className="overflow-x-auto rounded-lg border border-gray-200">
-                      <table className="w-full min-w-[600px] text-sm">
-                        <thead>
-                          <tr className="border-b border-gray-200 bg-gray-50">
+                    <div className="max-w-md space-y-2">
+                      <Label htmlFor="rep-search">Search by name or company</Label>
+                      <Input
+                        id="rep-search"
+                        type="search"
+                        value={searchInput}
+                        onChange={(e) => setSearchInput(e.target.value)}
+                        placeholder="Type to filter…"
+                        className="border-gray-200"
+                      />
+                    </div>
+
+                    {errorMessage && (
+                      <p className="text-sm text-red-600" role="alert">
+                        {errorMessage}
+                      </p>
+                    )}
+
+                    <div className="max-h-[min(60vh,520px)] overflow-auto rounded-lg border border-gray-200">
+                      <table className="w-full min-w-[720px] text-sm">
+                        <thead className="sticky top-0 z-10 bg-gray-50 shadow-sm">
+                          <tr className="border-b border-gray-200">
                             <th className="px-4 py-3 text-left font-semibold text-[#333333]">
                               Name
                             </th>
@@ -132,36 +210,28 @@ export default function AdminTagsPrintingPage() {
                               Title
                             </th>
                             <th className="px-4 py-3 text-left font-semibold text-[#333333]">
-                              Booth Location
+                              Booth
                             </th>
                             <th className="px-4 py-3 text-left font-semibold text-[#333333]">
-                              Time Added
+                              Building
+                            </th>
+                            <th className="px-4 py-3 text-left font-semibold text-[#333333]">
+                              Signed in
+                            </th>
+                            <th className="px-4 py-3 text-left font-semibold text-[#333333]">
+                              Print
                             </th>
                           </tr>
                         </thead>
                         <tbody>
-                          {PLACEHOLDER_REPRESENTATIVES.map((rep, i) => (
-                            <tr
-                              key={i}
-                              className="border-b border-gray-100 last:border-0 hover:bg-gray-50/50"
-                            >
-                              <td className="px-4 py-3 text-gray-700">{rep.name}</td>
-                              <td className="px-4 py-3 text-gray-700">{rep.company}</td>
-                              <td className="px-4 py-3 text-gray-700">{rep.title}</td>
-                              <td className="px-4 py-3 text-gray-700">{rep.booth}</td>
-                              <td className="px-4 py-3 text-gray-600">{rep.timeAdded}</td>
-                            </tr>
-                          ))}
+                          {renderTableBody(
+                            listQuery.isLoading,
+                            listQuery.data,
+                            handlePrintOne
+                          )}
                         </tbody>
                       </table>
                     </div>
-                    <Button
-                      type="button"
-                      onClick={handlePrint}
-                      className="bg-[#E00122] text-white hover:bg-[#B8011C] rounded-md"
-                    >
-                      Print tags
-                    </Button>
                   </div>
                 </CardContent>
               </Card>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -15,10 +15,12 @@ const ResourcesPage = lazy(() => import('@/pages/ResourcesPage'));
 
 // Admin pages
 const AdminLoginPage = lazy(() => import('@/pages/admin/AdminLoginPage'));
+const AdminChangePasswordPage = lazy(() => import('@/pages/admin/AdminChangePasswordPage'));
 const AdminDashboardPage = lazy(() => import('@/pages/admin/AdminDashboardPage'));
 const AdminReimbursementsPage = lazy(() => import('@/pages/admin/AdminReimbursementsPage'));
 const AdminRepresentativeSignInPage = lazy(() => import('@/pages/admin/AdminRepresentativeSignInPage'));
 const AdminTagsPrintingPage = lazy(() => import('@/pages/admin/AdminTagsPrintingPage'));
+const AdminResumeRosterPage = lazy(() => import('@/pages/admin/AdminResumeRosterPage'));
 const NotFoundPage = lazy(() => import('@/pages/NotFoundPage'));
 
 export const router = createBrowserRouter([
@@ -99,6 +101,14 @@ export const router = createBrowserRouter([
       </Suspense>
     ),
   },
+  {
+    path: '/admin/change-password',
+    element: (
+      <Suspense fallback={<LoadingFallback />}>
+        <AdminChangePasswordPage />
+      </Suspense>
+    ),
+  },
   // Admin (protected)
   {
     path: '/admin',
@@ -136,6 +146,16 @@ export const router = createBrowserRouter([
       <AdminGuard>
         <Suspense fallback={<LoadingFallback />}>
           <AdminTagsPrintingPage />
+        </Suspense>
+      </AdminGuard>
+    ),
+  },
+  {
+    path: '/admin/resume-review-day/roster',
+    element: (
+      <AdminGuard>
+        <Suspense fallback={<LoadingFallback />}>
+          <AdminResumeRosterPage />
         </Suspense>
       </AdminGuard>
     ),

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 import LoadingFallback from '@/components/LoadingFallback';
 import { AdminGuard } from '@/components/AdminGuard';
+import { RootLayout } from '@/components/RootLayout';
 
 // Lazy load pages
 const HomePage = lazy(() => import('@/pages/HomePage'));
@@ -26,147 +27,151 @@ const NotFoundPage = lazy(() => import('@/pages/NotFoundPage'));
 export const router = createBrowserRouter([
   {
     path: '/',
-    element: (
-      <Suspense fallback={<LoadingFallback />}>
-        <HomePage />
-      </Suspense>
-    ),
-  },
-  {
-    path: '/committees',
-    element: (
-      <Suspense fallback={<LoadingFallback />}>
-        <CommitteesPage />
-      </Suspense>
-    ),
-  },
-  {
-    path: '/career-fair',
-    element: (
-      <Suspense fallback={<LoadingFallback />}>
-        <CareerFairPage />
-      </Suspense>
-    )
-  },
-  {
-    path: '/expo',
-    element: (
-      <Suspense fallback={<LoadingFallback />}>
-        <ExpoPage />
-      </Suspense>
-    ),
-  },
-  {
-    path: '/executives',
-    element: <Navigate to="/committees" replace />,
-  },
-  {
-    path: '/alumni',
-    element: (
-      <Suspense fallback={<LoadingFallback />}>
-        <AlumniPage />
-      </Suspense>
-    ),
-  },
-  {
-    path: '/resume-review-day/employers',
-    element: (
-      <Suspense fallback={<LoadingFallback />}>
-        <ResumeReviewEmployer />
-      </Suspense>
-    )
-  },
-   {
-    path: '/resume-review-day/students',
-    element: (
-      <Suspense fallback={<LoadingFallback />}>
-        <ResumeReviewStudent />
-      </Suspense>
-    )
-  },
-  {
-    path: '/resources',
-    element: (
-      <Suspense fallback={<LoadingFallback />}>
-        <ResourcesPage />
-      </Suspense>
-    ),
-  },
-  // Admin (public)
-  {
-    path: '/admin/login',
-    element: (
-      <Suspense fallback={<LoadingFallback />}>
-        <AdminLoginPage />
-      </Suspense>
-    ),
-  },
-  {
-    path: '/admin/change-password',
-    element: (
-      <Suspense fallback={<LoadingFallback />}>
-        <AdminChangePasswordPage />
-      </Suspense>
-    ),
-  },
-  // Admin (protected)
-  {
-    path: '/admin',
-    element: (
-      <AdminGuard>
-        <Suspense fallback={<LoadingFallback />}>
-          <AdminDashboardPage />
-        </Suspense>
-      </AdminGuard>
-    ),
-  },
-  {
-    path: '/admin/reimbursements',
-    element: (
-      <AdminGuard>
-        <Suspense fallback={<LoadingFallback />}>
-          <AdminReimbursementsPage />
-        </Suspense>
-      </AdminGuard>
-    ),
-  },
-  {
-    path: '/admin/career-fair/representative-sign-in',
-    element: (
-      <AdminGuard>
-        <Suspense fallback={<LoadingFallback />}>
-          <AdminRepresentativeSignInPage />
-        </Suspense>
-      </AdminGuard>
-    ),
-  },
-  {
-    path: '/admin/career-fair/tags',
-    element: (
-      <AdminGuard>
-        <Suspense fallback={<LoadingFallback />}>
-          <AdminTagsPrintingPage />
-        </Suspense>
-      </AdminGuard>
-    ),
-  },
-  {
-    path: '/admin/resume-review-day/roster',
-    element: (
-      <AdminGuard>
-        <Suspense fallback={<LoadingFallback />}>
-          <AdminResumeRosterPage />
-        </Suspense>
-      </AdminGuard>
-    ),
-  },
-  {
-    path: '*',
-    element: (
-      <Suspense fallback={<LoadingFallback />}>
-        <NotFoundPage />
-      </Suspense>
-    ),
+    element: <RootLayout />,
+    children: [
+      {
+        index: true,
+        element: (
+          <Suspense fallback={<LoadingFallback />}>
+            <HomePage />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'committees',
+        element: (
+          <Suspense fallback={<LoadingFallback />}>
+            <CommitteesPage />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'career-fair',
+        element: (
+          <Suspense fallback={<LoadingFallback />}>
+            <CareerFairPage />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'expo',
+        element: (
+          <Suspense fallback={<LoadingFallback />}>
+            <ExpoPage />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'executives',
+        element: <Navigate to="/committees" replace />,
+      },
+      {
+        path: 'alumni',
+        element: (
+          <Suspense fallback={<LoadingFallback />}>
+            <AlumniPage />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'resume-review-day/employers',
+        element: (
+          <Suspense fallback={<LoadingFallback />}>
+            <ResumeReviewEmployer />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'resume-review-day/students',
+        element: (
+          <Suspense fallback={<LoadingFallback />}>
+            <ResumeReviewStudent />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'resources',
+        element: (
+          <Suspense fallback={<LoadingFallback />}>
+            <ResourcesPage />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'admin/login',
+        element: (
+          <Suspense fallback={<LoadingFallback />}>
+            <AdminLoginPage />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'admin/change-password',
+        element: (
+          <Suspense fallback={<LoadingFallback />}>
+            <AdminChangePasswordPage />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'admin',
+        element: (
+          <AdminGuard>
+            <Suspense fallback={<LoadingFallback />}>
+              <AdminDashboardPage />
+            </Suspense>
+          </AdminGuard>
+        ),
+      },
+      {
+        path: 'admin/reimbursements',
+        element: (
+          <AdminGuard>
+            <Suspense fallback={<LoadingFallback />}>
+              <AdminReimbursementsPage />
+            </Suspense>
+          </AdminGuard>
+        ),
+      },
+      {
+        path: 'admin/career-fair/representative-sign-in',
+        element: (
+          <AdminGuard>
+            <Suspense fallback={<LoadingFallback />}>
+              <AdminRepresentativeSignInPage />
+            </Suspense>
+          </AdminGuard>
+        ),
+      },
+      {
+        path: 'admin/career-fair/tags',
+        element: (
+          <AdminGuard>
+            <Suspense fallback={<LoadingFallback />}>
+              <AdminTagsPrintingPage />
+            </Suspense>
+          </AdminGuard>
+        ),
+      },
+      {
+        path: 'admin/resume-review-day/roster',
+        element: (
+          <AdminGuard>
+            <Suspense fallback={<LoadingFallback />}>
+              <AdminResumeRosterPage />
+            </Suspense>
+          </AdminGuard>
+        ),
+      },
+      {
+        path: '*',
+        element: (
+          <Suspense fallback={<LoadingFallback />}>
+            <NotFoundPage />
+          </Suspense>
+        ),
+      },
+    ],
   },
 ]);
 

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -1,0 +1,145 @@
+import axios, { type AxiosError } from "axios";
+
+const HOST_URL = import.meta.env.VITE_HOST_URL as string | undefined;
+const baseURL =
+  HOST_URL !== undefined && HOST_URL !== "" ? HOST_URL : "";
+
+/** In-memory JWT storage (not persisted; refresh clears on page reload). */
+let accessToken: string | null = null;
+/** After login / refreshMe; cleared after successful password change. */
+let mustChangePassword = false;
+/** Mirrors /dashboard/auth/me/ is_staff — SPA admin is staff-only. */
+let isStaffUser = false;
+/** Username from last /me response (for client-side password rules). */
+let cachedUsername: string | null = null;
+
+const api = axios.create({
+  baseURL,
+  withCredentials: false,
+});
+
+export interface TokenPair {
+  access: string;
+  refresh: string;
+}
+
+export interface AuthMeResponse {
+  username: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  must_change_password: boolean;
+  is_staff: boolean;
+  is_superuser: boolean;
+  is_exec: boolean;
+}
+
+function setMustChangePassword(value: boolean): void {
+  mustChangePassword = value;
+}
+
+export function getMustChangePassword(): boolean {
+  return mustChangePassword;
+}
+
+export function getAccessToken(): string | null {
+  return accessToken;
+}
+
+export function isAuthenticated(): boolean {
+  return accessToken !== null;
+}
+
+export function logout(): void {
+  accessToken = null;
+  mustChangePassword = false;
+  isStaffUser = false;
+  cachedUsername = null;
+}
+
+export function getIsStaffUser(): boolean {
+  return isStaffUser;
+}
+
+export function getCachedUsername(): string | null {
+  return cachedUsername;
+}
+
+function authHeader(): { Authorization: string } | Record<string, never> {
+  if (!accessToken) return {};
+  return { Authorization: `Bearer ${accessToken}` };
+}
+
+/**
+ * Fetch current user; updates in-memory must-change-password flag.
+ */
+export async function refreshMe(): Promise<AuthMeResponse> {
+  const { data } = await api.get<AuthMeResponse>("/dashboard/auth/me/", {
+    headers: authHeader(),
+  });
+  cachedUsername = data.username;
+  setMustChangePassword(!!data.must_change_password);
+  isStaffUser = !!data.is_staff;
+  return data;
+}
+
+/**
+ * Obtain JWT and load /me. Tokens stored in memory only.
+ */
+export async function login(
+  username: string,
+  password: string
+): Promise<{ mustChangePassword: boolean }> {
+  const { data } = await api.post<TokenPair>("/api/token/", {
+    username: username.trim(),
+    password,
+  });
+  accessToken = data.access;
+
+  const me = await refreshMe();
+  return { mustChangePassword: !!me.must_change_password };
+}
+
+export interface ChangePasswordPayload {
+  old_password: string;
+  new_password: string;
+  new_password_confirm: string;
+}
+
+export async function changePassword(payload: ChangePasswordPayload): Promise<void> {
+  await api.post("/dashboard/auth/change-password/", payload, {
+    headers: authHeader(),
+  });
+  setMustChangePassword(false);
+}
+
+function formatErrorMessage(err: unknown): string {
+  const ax = err as AxiosError<Record<string, unknown>>;
+  if (!axios.isAxiosError(err)) {
+    return "Something went wrong. Please try again.";
+  }
+  const d = ax.response?.data;
+  if (typeof d === "string") return d;
+  if (d && typeof d === "object") {
+    const detail = d.detail;
+    if (typeof detail === "string") return detail;
+    if (Array.isArray(detail) && detail.length) return String(detail[0]);
+    const nonField = d.non_field_errors;
+    if (Array.isArray(nonField) && nonField.length) return String(nonField[0]);
+    const firstKey = Object.keys(d)[0];
+    const val = firstKey ? (d as Record<string, unknown>)[firstKey] : undefined;
+    if (Array.isArray(val) && val.length) return String(val[0]);
+    if (typeof val === "string") return val;
+  }
+  if (ax.response?.status === 401) return "Invalid username or password.";
+  if (ax.response?.status === 403) {
+    const d403 = ax.response?.data;
+    if (d403 && typeof d403 === "object" && typeof (d403 as { detail?: string }).detail === "string") {
+      return (d403 as { detail: string }).detail;
+    }
+    return "Access denied. Staff accounts only.";
+  }
+  return "Request failed. Please try again.";
+}
+
+export { formatErrorMessage };

--- a/src/services/CareerFairService.ts
+++ b/src/services/CareerFairService.ts
@@ -1,0 +1,114 @@
+import axios from "axios";
+
+import { getAccessToken } from "@/services/AuthService";
+
+const HOST_URL = import.meta.env.VITE_HOST_URL as string | undefined;
+const baseURL =
+  HOST_URL !== undefined && HOST_URL !== "" ? HOST_URL : "";
+
+const api = axios.create({
+  baseURL,
+  withCredentials: false,
+});
+
+export interface Representative {
+  id: string;
+  name: string;
+  company: string;
+  title: string;
+  email: string;
+  booth_location: string;
+  building_location: string;
+  signed_in_at: string;
+}
+
+export interface RepresentativePayload {
+  name: string;
+  company: string;
+  title: string;
+  email: string;
+  booth_location: string;
+  building_location: string;
+}
+
+/** TanStack Query key prefix for representative lists (search adds a second segment). */
+export const CAREER_FAIR_REPRESENTATIVES_QUERY_KEY = ["career-fair-representatives"] as const;
+
+interface PaginatedRepresentatives {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: Representative[];
+}
+
+function authHeader(): { Authorization: string } | Record<string, never> {
+  const token = getAccessToken();
+  if (!token) return {};
+  return { Authorization: `Bearer ${token}` };
+}
+
+function isPaginated(data: unknown): data is PaginatedRepresentatives {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "results" in data &&
+    Array.isArray((data as PaginatedRepresentatives).results)
+  );
+}
+
+/**
+ * Public POST — representative sign-in (no JWT).
+ */
+export async function signInRepresentative(
+  payload: RepresentativePayload
+): Promise<Representative> {
+  const { data } = await api.post<Representative>(
+    "/api/career-fair/representatives/",
+    payload
+  );
+  return data;
+}
+
+async function fetchRepresentativesPage(
+  pageUrl: string
+): Promise<{ items: Representative[]; next: string | null }> {
+  const response = await api.get<PaginatedRepresentatives | Representative[]>(pageUrl, {
+    headers: authHeader(),
+  });
+  const body = response.data;
+  if (Array.isArray(body)) {
+    return { items: body, next: null };
+  }
+  if (isPaginated(body)) {
+    return { items: body.results, next: body.next };
+  }
+  return { items: [], next: null };
+}
+
+/**
+ * Authenticated GET — list representatives; optional search on name/company.
+ * Follows DRF pagination until all pages are loaded.
+ */
+export async function getRepresentatives(search?: string): Promise<Representative[]> {
+  const params = new URLSearchParams();
+  const q = (search ?? "").trim();
+  if (q) params.set("search", q);
+
+  const query = params.toString();
+  let nextUrl: string | null =
+    query.length > 0
+      ? `/api/career-fair/representatives/?${query}`
+      : "/api/career-fair/representatives/";
+
+  const collected: Representative[] = [];
+
+  while (nextUrl) {
+    const { items, next } = await fetchRepresentativesPage(nextUrl);
+    collected.push(...items);
+    nextUrl = next;
+  }
+
+  return collected;
+}
+
+export { formatErrorMessage } from "@/services/AuthService";

--- a/src/services/CommitteesService.ts
+++ b/src/services/CommitteesService.ts
@@ -2,7 +2,11 @@ import axios from 'axios';
 
 export type CommitteeColor = 'indigo' | 'teal' | 'sky' | 'rose';
 
-const HOST_URL = import.meta.env.VITE_HOST_URL as string;
+const HOST_URL = import.meta.env.VITE_HOST_URL as string | undefined;
+const baseURL =
+  HOST_URL !== undefined && HOST_URL !== ''
+    ? HOST_URL
+    : '';
 
 /** Executive member (from GET /dashboard/exec-member/?roleId= or embedded in exec-role). */
 export interface ExecMemberPerson {
@@ -39,34 +43,30 @@ export interface Committee {
 }
 
 const axiosInstance = axios.create({
-  baseURL: HOST_URL,
+  baseURL,
   withCredentials: false,
 });
 
 export const CommitteesService = {
   /** GET /dashboard/exec-role -> ExecRoleSection[] (Officers, CoS, VPCA, VPE with roles). */
   async getExecRoleSections(): Promise<ExecRoleSection[]> {
-    const { data } = await axiosInstance.get<ExecRoleSection[]>(
-      `${HOST_URL}/dashboard/exec-role`
-    );
+    const { data } = await axiosInstance.get<ExecRoleSection[]>('/dashboard/exec-role/');
     return data;
   },
 
   /** GET /dashboard/exec-role?include_members=true -> sections with roles and members in one call. */
   async getExecRoleSectionsWithMembers(): Promise<ExecRoleSection[]> {
-    const { data } = await axiosInstance.get<ExecRoleSection[]>(
-      `${HOST_URL}/dashboard/exec-role`,
-      { params: { include_members: "true" } }
-    );
+    const { data } = await axiosInstance.get<ExecRoleSection[]>('/dashboard/exec-role/', {
+      params: { include_members: 'true' },
+    });
     return data;
   },
 
   /** GET /dashboard/exec-member/?roleId= -> ExecMemberPerson[] for a given role. */
   async getExecMembersByRoleId(roleId: number): Promise<ExecMemberPerson[]> {
-    const { data } = await axiosInstance.get<ExecMemberPerson[]>(
-      `${HOST_URL}/dashboard/exec-member/`,
-      { params: { roleId } }
-    );
+    const { data } = await axiosInstance.get<ExecMemberPerson[]>('/dashboard/exec-member/', {
+      params: { roleId },
+    });
     return data;
   },
 

--- a/src/services/ResumeReviewService.ts
+++ b/src/services/ResumeReviewService.ts
@@ -1,16 +1,19 @@
 import axios from 'axios';
 
+import { getAccessToken } from '@/services/AuthService';
+
 const HOST_URL = import.meta.env.VITE_HOST_URL as string | undefined;
 const baseURL =
   HOST_URL !== undefined && HOST_URL !== ''
     ? HOST_URL
     : ''; // In dev with no env, use same origin so Vite proxy handles /api
 
-export interface EmployerResponse {
-  message: string 
-  status: string
+export interface EmployerRegisterResponse {
+  message: string;
+  id?: string;
 }
 
+/** POST /api/resume-review-day/employer/ — `max_resumes` is set server-side from the time window. */
 export interface EmployerData {
   full_name: string;
   company_name: string;
@@ -19,9 +22,17 @@ export interface EmployerData {
   diet_restriction: string;
   start_time: string;
   end_time: string;
-  max_resumes: number;
   uc_alumni: boolean;
   selected_majors: string[];
+}
+
+/** Public GET /api/resume-review-day/employer/ list item */
+export interface EmployerListItem {
+  id: string;
+  full_name: string;
+  company_name: string;
+  selected_majors: string[];
+  available_slots: number;
 }
 
 export interface StudentData {
@@ -33,11 +44,16 @@ export interface StudentData {
   timeslots: string[]; // Timeslot IDs
 }
 
+export interface AssignedTimeslotEntry {
+  id: string;
+  timeslot: string;
+}
+
 export interface StudentResponse {
-  message: string
-  student_id: string
-  full_name: string
-  assigned_timeslots: string[]
+  message: string;
+  student_id: string;
+  full_name: string;
+  assigned_timeslots: AssignedTimeslotEntry[];
 }
 
 export interface EmployerTimeslot {
@@ -53,6 +69,38 @@ export interface Timeslot {
     timeslot?: string  // API returns this for TimeField
 }
 
+/** GET /api/resume-review-day/roster/ (authenticated) */
+export interface RosterStudent {
+  id: string;
+  full_name: string;
+  email: string;
+  major: string;
+  grad_year: number;
+}
+
+export interface RosterSlot {
+  slot_id: string;
+  time: string;
+  student: RosterStudent | null;
+}
+
+export interface RosterEmployer {
+  id: string;
+  full_name: string;
+  company_name: string;
+  email: string;
+  selected_majors: string[];
+  start_time: string;
+  end_time: string;
+  max_resumes: number;
+  slots: RosterSlot[];
+}
+
+function authHeader(): { Authorization: string } | Record<string, never> {
+  const token = getAccessToken();
+  if (!token) return {};
+  return { Authorization: `Bearer ${token}` };
+}
 
 const axiosInstance = axios.create({
   baseURL,
@@ -70,13 +118,33 @@ export const ResumeReviewDay = {
     if (params?.major) searchParams.set('major', params.major);
     if (params?.time?.length) params.time.forEach((t) => searchParams.append('time', t));
     const query = searchParams.toString();
-    const url = query ? `/api/resume-review-day/timeslots?${query}` : '/api/resume-review-day/timeslots';
+    const url = query
+      ? `/api/resume-review-day/timeslots/?${query}`
+      : '/api/resume-review-day/timeslots/';
     const { data } = await axiosInstance.get<EmployerTimeslot[]>(url);
     return data;
   },
 
+  async getEmployers(): Promise<EmployerListItem[]> {
+    const { data } = await axiosInstance.get<EmployerListItem[]>(
+      '/api/resume-review-day/employer/'
+    );
+    return data;
+  },
+
+  async getRoster(): Promise<RosterEmployer[]> {
+    const { data } = await axiosInstance.get<RosterEmployer[]>(
+      '/api/resume-review-day/roster/',
+      { headers: authHeader() }
+    );
+    return data;
+  },
+
   async registerEmployer(data: Record<string, unknown>) {
-    const response = await axiosInstance.post('/api/resume-review-day/employer/', data);
+    const response = await axiosInstance.post<EmployerRegisterResponse>(
+      '/api/resume-review-day/employer/',
+      data
+    );
     return { data: response.data, status: response.status };
   },
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,10 @@ export default defineConfig(({ mode }) => {
           target: apiTarget,
           changeOrigin: true,
         },
+        '/dashboard': {
+          target: apiTarget,
+          changeOrigin: true,
+        },
       },
     },
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new JWT-based admin authentication and authorization gating plus new authenticated data fetches; mistakes could lock out staff users or expose protected data. Token storage is in-memory (no persistence), so session/refresh behavior may be surprising and needs careful review.
> 
> **Overview**
> **Replaces the demo admin login/localStorage guard with real JWT auth.** Adds `AuthService` for `/api/token/`, `/dashboard/auth/me/`, and `/dashboard/auth/change-password/`, updates `AdminGuard`/`Navbar`/`AdminLoginPage` to use it, and introduces a forced `/admin/change-password` flow for accounts flagged `must_change_password` (staff-only enforcement).
> 
> **Wires several pages to backend APIs via TanStack Query.** `CommitteesPage` moves from manual `useEffect` fetching to `useQuery`, `CareerFairPage` now shows a public “Resume Review Day signed up employers” section, and admin pages now call new services: representative sign-in submits to `/api/career-fair/representatives/`, tags printing lists/searches reps (polling) instead of placeholder data, and a new `AdminResumeRosterPage` shows the authenticated Resume Review Day roster.
> 
> **Standardizes API base URL/proxy setup.** Adds `.env.local.example`, makes services tolerate empty `VITE_HOST_URL`, and extends Vite dev proxy to forward `/dashboard` to the backend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d82baf6e9985a5da9d3206850dcac9490410e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->